### PR TITLE
fix(fe/styles): consolidate color variables

### DIFF
--- a/docs/css-documentation.md
+++ b/docs/css-documentation.md
@@ -11,7 +11,8 @@ resources/css/
 ├── _reset.scss         # CSS Resets
 ├── variables/          # Variable definitions
 │   ├── _main-colors.scss
-│   └── _layout.scss
+│   ├── _layout.scss
+│   └── _exception-colors.scss
 ├── components/         # Styles for specific components
 │   ├── _buttons.scss
 │   ├── _menu-item-card.scss
@@ -22,6 +23,28 @@ resources/css/
     ├── _auth.scss
     └── _restaurant-show.scss
 ```
+
+## Style Guidelines
+### Color Management
+- **No Hardcoded Colors**: Colors must not be defined outside of a colors variable file.
+- **Preferred Source**: Always look for a suitable replacement in `variables/_main-colors.scss`.
+- **Exceptions**: If absolutely no suitable replacement/match can be found, create a variable in `variables/_exception-colors.scss`.
+
+### Sass Modules
+- **Use `@use`**: Always use the `@use` rule to load mixins, functions, and variables from other Sass files. Do not use `@import` as it is deprecated.
+- **Namespacing**: Utilize the automatic namespacing provided by `@use` (e.g., `main-colors.$brand-primary`) to avoid naming collisions and make dependencies explicit.
+
+### Nesting
+- **Limit Depth**: Avoid nesting selectors more than 3 levels deep. Deep nesting increases CSS specificity and makes overriding styles difficult.
+- **Readability**: Use nesting primarily to scope styles to a component or to group related states (like `&:hover`).
+
+### Naming Conventions
+- **Kebab-case**: Use `kebab-case` for all class names, variables, and filenames (e.g., `.btn-primary`, `$text-secondary`, `_main-colors.scss`).
+- **Descriptive Names**: Choose class names that describe the *purpose* or *content* of the element, not its appearance (e.g., `.error-message` instead of `.red-text`).
+
+### Responsive Design
+- **Mobile-First**: Write base styles for mobile devices first.
+- **Media Queries**: Use `min-width` media queries to layer on styles for larger screens (tablets, desktops).
 
 ## Base
 ### `_reset.scss`
@@ -45,6 +68,9 @@ Defines the color palette for the application.
 Defines structural variables.
 - **Borders**: `$border-radius` (8px), `$border-radius-pill`.
 - **Shadows**: `$box-shadow` for elevated elements.
+
+### `variables/_exception-colors.scss`
+Contains color definitions that do not fit into the main color palette but are necessary for specific UI elements. Use sparingly.
 
 ## Layouts
 ### `layouts/_customer.scss`

--- a/resources/css/_variables.scss
+++ b/resources/css/_variables.scss
@@ -1,3 +1,4 @@
 // Variables Partials
 @use 'variables/main-colors';
 @use 'variables/layout';
+@use 'variables/exception-colors';

--- a/resources/css/components/_menu-item-card.scss
+++ b/resources/css/components/_menu-item-card.scss
@@ -30,7 +30,7 @@
             color: main-colors.$text-inverse;
             font-size: 1.2rem;
             letter-spacing: 1px;
-            text-shadow: 0 1px 2px rgba(0,0,0,0.2);
+            text-shadow: 0 1px 2px main-colors.$shadow-color-text;
         }
     }
 

--- a/resources/css/layouts/_customer.scss
+++ b/resources/css/layouts/_customer.scss
@@ -10,9 +10,9 @@
     @media (min-width: 1024px) {
         max-width: 768px; // Constrain width to simulate mobile/tablet view
         margin: 0 auto;
-        border-left: 1px solid #eee;
-        border-right: 1px solid #eee;
-        background-color: #fff; // Ensure content has background
+        border-left: 1px solid main-colors.$bg-alt-1;
+        border-right: 1px solid main-colors.$bg-alt-1;
+        background-color: main-colors.$bg-surface; // Ensure content has background
         min-height: 100vh;
     }
 
@@ -40,8 +40,8 @@
             width: 768px; // Match max-width of .customer-layout
             left: 50%;
             transform: translateX(-50%);
-            border-left: 1px solid #eee;
-            border-right: 1px solid #eee;
+            border-left: 1px solid main-colors.$bg-alt-1;
+            border-right: 1px solid main-colors.$bg-alt-1;
         }
 
         .nav-item {

--- a/resources/css/pages/_auth.scss
+++ b/resources/css/pages/_auth.scss
@@ -1,5 +1,6 @@
 @use "../variables/layout";
 @use "../variables/main-colors";
+@use "../variables/exception-colors";
 
 .auth-page {
     min-height: 100vh;
@@ -36,7 +37,7 @@
             .status-message {
                 margin-top: 1rem;
                 font-size: 0.875rem;
-                color: #16a34a; // green-600
+                color: exception-colors.$status-success;
             }
         }
 
@@ -74,12 +75,12 @@
 
                 .error-message {
                     font-size: 0.75rem;
-                    color: #dc2626; // Red for errors
+                    color: exception-colors.$status-error;
                     margin-top: 0.25rem;
                     font-weight: 500;
-                    background-color: #fef2f2;
+                    background-color: main-colors.$bg-alt-1;
                     padding: 0.5rem;
-                    border: 1px solid #fecaca;
+                    border: 1px solid main-colors.$border-light;
                     border-radius: 0.25rem;
                 }
             }
@@ -106,7 +107,7 @@
 
                         &:focus {
                             outline: none;
-                            box-shadow: 0 0 0 2px rgba(main-colors.$brand-primary, 0.2);
+                            box-shadow: 0 0 0 2px main-colors.$brand-primary-soft;
                         }
                     }
                 }

--- a/resources/css/pages/_profile.scss
+++ b/resources/css/pages/_profile.scss
@@ -59,7 +59,7 @@
     background-color: main-colors.$bg-surface;
     border-radius: layout.$border-radius;
     padding: 1.5rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px main-colors.$shadow-color-strong;
     margin-bottom: 1.5rem;
 }
 
@@ -159,7 +159,7 @@
     background-color: main-colors.$bg-surface;
     border-radius: layout.$border-radius;
     padding: 1.5rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px main-colors.$shadow-color-strong;
 
     .section-header {
         display: flex;

--- a/resources/css/pages/_restaurant-index.scss
+++ b/resources/css/pages/_restaurant-index.scss
@@ -32,7 +32,7 @@
     border: 1px solid main-colors.$border-light;
     border-radius: layout.$border-radius;
     padding: 0.75rem 1rem;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 1px 2px main-colors.$shadow-color;
 
     .search-icon {
         font-size: 1.25rem;
@@ -88,7 +88,7 @@
     background-color: main-colors.$bg-surface;
     border-radius: layout.$border-radius;
     overflow: hidden;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px main-colors.$shadow-color-strong;
     transition: box-shadow 0.2s ease;
 
     &:hover {

--- a/resources/css/pages/_restaurant-show.scss
+++ b/resources/css/pages/_restaurant-show.scss
@@ -28,7 +28,7 @@
                 height: 40px;
                 border-radius: 50%;
                 color: main-colors.$text-inverse;
-                background-color: rgba(0, 0, 0, 0.3);
+                background-color: main-colors.$overlay-light;
                 backdrop-filter: blur(4px);
                 transition: all 0.2s ease;
 
@@ -39,7 +39,7 @@
                 }
 
                 &:hover {
-                    background-color: rgba(0, 0, 0, 0.5);
+                    background-color: main-colors.$overlay-dark;
                     transform: scale(1.05);
                 }
             }

--- a/resources/css/variables/_exception-colors.scss
+++ b/resources/css/variables/_exception-colors.scss
@@ -1,0 +1,9 @@
+// ======================================================================
+// EXCEPTION / STATUS COLORS
+// ======================================================================
+
+$status-success: #16a34a;
+// Purpose: Success messages.
+
+$status-error: #dc2626;
+// Purpose: Error text.

--- a/resources/css/variables/_layout.scss
+++ b/resources/css/variables/_layout.scss
@@ -2,9 +2,11 @@
 // LAYOUT VARIABLES (Preserved)
 // ======================================================================
 
+@use "main-colors";
+
 // Borders
 $border-radius: 8px;
 $border-radius-pill: 9999px;
 
 // Shadows
-$box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+$box-shadow: 0 4px 6px -1px main-colors.$shadow-color-strong, 0 2px 4px -1px main-colors.$shadow-color-medium;

--- a/resources/css/variables/_main-colors.scss
+++ b/resources/css/variables/_main-colors.scss
@@ -109,3 +109,18 @@ $disabled-text: color.adjust($text-secondary, $lightness: 35%);
 
 $shadow-color: rgba(0, 0, 0, 0.05);
 // Purpose: Soft card shadows (as seen in your mockup).
+
+$shadow-color-strong: rgba(0, 0, 0, 0.1);
+// Purpose: Stronger shadow.
+
+$shadow-color-medium: rgba(0, 0, 0, 0.06);
+// Purpose: Medium shadow.
+
+$shadow-color-text: rgba(0, 0, 0, 0.2);
+// Purpose: Text shadow.
+
+$overlay-light: rgba(0, 0, 0, 0.3);
+// Purpose: Light overlay.
+
+$overlay-dark: rgba(0, 0, 0, 0.5);
+// Purpose: Dark overlay.


### PR DESCRIPTION
Id like to keep al colors definitions centralized in the `...colors.scss` variable files

It will help with only using our color pallete, and make future refactoring easier.

Added a 'Style Guidelines' section to css documentation, make sure to tell AI to follow those instructions when its making styles