### PR TITLE
fix(favorites): n+1 query issue

### DIFF
--- a/app/Http/Controllers/Customer/ProfileController.php
+++ b/app/Http/Controllers/Customer/ProfileController.php
@@ -223,7 +223,7 @@ class ProfileController extends Controller
         \DB::table('favorite_restaurants')->upsert(
             $upsertData,
             // 1. The "Matcher": Unique columns used to identify if a record already exists.
-            // If a row with this specific customer_id AND restaurant_id is found...
+            // If a row with this specific customer_user_id AND restaurant_id is found...
             ['customer_user_id', 'restaurant_id'],
 
             // 2. The "Updater": Columns to update if a match is found.

--- a/docs/thesis-features.md
+++ b/docs/thesis-features.md
@@ -229,13 +229,13 @@ We implemented an optimized solution using Laravel's `upsert` method, which comp
 - **Round-trips:** Reduced from $O(N)$ to $O(1)$.
 - **Atomicity:** The entire batch is processed as a single atomic operation, ensuring data consistency without needing an explicit application-level transaction wrapper for the write itself.
 - **Locking:** Reduces lock contention on the table compared to multiple sequential updates.
-  a
-  **Implementation:**
+
+**Implementation:**
 
 ```php
 \DB::table('favorite_restaurants')->upsert(
-    $upsertData,
-    ['customer_user_id', 'restaurant_id'], // Unique keys identifying the record
-    ['rank', 'updated_at']                 // Columns to update on collision
+$upsertData,
+['customer_user_id', 'restaurant_id'], // Unique keys identifying the record
+['rank', 'updated_at'] // Columns to update on collision
 );
 ```


### PR DESCRIPTION
This loop executes N+1 queries for each function call, we should only use 1 query here. We can use an UPSERT query for this bulk update